### PR TITLE
Downgrade TypeScript for TypeDoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11447,9 +11447,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "simple-git-hooks": "^2.4.1",
     "ts-jest": "^26.5.6",
     "typedoc": "^0.20.36",
-    "typescript": "^4.3.2"
+    "typescript": "4.2.4"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

TypeDoc doesn't yet support TypeScript 4.3.x, resulting in errors during doc generation: https://github.com/product-os/jellyfish-plugin-github/runs/2690366490?check_suite_focus=true