### PR TITLE
Add missing GET contents balena.yml test stubs

### DIFF
--- a/test/integration/webhooks/github/open-pr-and-create-repos/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
+++ b/test/integration/webhooks/github/open-pr-and-create-repos/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/resin-io/jellyfish/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/resin-io/jellyfish/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/resin-io/jellyfish/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/pr-approve-merge/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
+++ b/test/integration/webhooks/github/pr-approve-merge/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/resin-io/jellyfish/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/resin-io/jellyfish/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/resin-io/jellyfish/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/pr-changes-requested/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
+++ b/test/integration/webhooks/github/pr-changes-requested/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/resin-io/jellyfish/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/resin-io/jellyfish/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/resin-io/jellyfish/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/pr-comment/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
+++ b/test/integration/webhooks/github/pr-comment/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/resin-io/jellyfish/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/resin-io/jellyfish/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/resin-io/jellyfish/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/pr-inline-comment/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
+++ b/test/integration/webhooks/github/pr-inline-comment/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/resin-io/jellyfish/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/resin-io/jellyfish/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/resin-io/jellyfish/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/pr-label/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
+++ b/test/integration/webhooks/github/pr-label/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/resin-io/jellyfish/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/resin-io/jellyfish/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/resin-io/jellyfish/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/pr-open-close/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
+++ b/test/integration/webhooks/github/pr-open-close/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/resin-io/jellyfish/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/resin-io/jellyfish/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/resin-io/jellyfish/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/pr-open-from-fork/stubs/1/repos-balena-io-vb-test-contents-balena-yml-ref-61-c-13-a-539195-aece-8506-f-4-f-7-eb-1-c-01765-e-935891.json
+++ b/test/integration/webhooks/github/pr-open-from-fork/stubs/1/repos-balena-io-vb-test-contents-balena-yml-ref-61-c-13-a-539195-aece-8506-f-4-f-7-eb-1-c-01765-e-935891.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/balena-io/vb-test/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/balena-io/vb-test/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/balena-io/vb-test/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/balena-io/vb-test/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/balena-io/vb-test/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/balena-io/vb-test/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/balena-io/vb-test/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/pr-review-request/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
+++ b/test/integration/webhooks/github/pr-review-request/stubs/1/repos-resin-io-jellyfish-contents-balena-yml-ref-803-d-0-ccc-315-e-606-fe-8-d-00-cf-52138-de-654-c-3-f-35-aa.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/resin-io/jellyfish/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/resin-io/jellyfish/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/resin-io/jellyfish/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/resin-io/jellyfish/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/resin-io/jellyfish/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/push-to-open-pr-from-fork/stubs/1/repos-balena-io-vb-test-contents-balena-yml-ref-61-c-13-a-539195-aece-8506-f-4-f-7-eb-1-c-01765-e-935891.json
+++ b/test/integration/webhooks/github/push-to-open-pr-from-fork/stubs/1/repos-balena-io-vb-test-contents-balena-yml-ref-61-c-13-a-539195-aece-8506-f-4-f-7-eb-1-c-01765-e-935891.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/balena-io/vb-test/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/balena-io/vb-test/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/balena-io/vb-test/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/balena-io/vb-test/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/balena-io/vb-test/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/balena-io/vb-test/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/balena-io/vb-test/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/push-to-open-pr-from-fork/stubs/1/repos-balena-io-vb-test-contents-balena-yml-ref-b-9-dba-648-e-8-f-751-fff-4-a-6-b-3454-b-8-d-6166-c-77-b-132-b.json
+++ b/test/integration/webhooks/github/push-to-open-pr-from-fork/stubs/1/repos-balena-io-vb-test-contents-balena-yml-ref-b-9-dba-648-e-8-f-751-fff-4-a-6-b-3454-b-8-d-6166-c-77-b-132-b.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/balena-io/vb-test/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/balena-io/vb-test/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/balena-io/vb-test/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/balena-io/vb-test/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/balena-io/vb-test/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/balena-io/vb-test/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/balena-io/vb-test/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/push-to-open-pr/stubs/1/repos-balena-io-vb-test-contents-balena-yml-ref-70-b-9-a-5-f-59-ebf-35-cff-5265-f-30-c-8-b-33-ecae-15-ddad-5.json
+++ b/test/integration/webhooks/github/push-to-open-pr/stubs/1/repos-balena-io-vb-test-contents-balena-yml-ref-70-b-9-a-5-f-59-ebf-35-cff-5265-f-30-c-8-b-33-ecae-15-ddad-5.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/balena-io/vb-test/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/balena-io/vb-test/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/balena-io/vb-test/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/balena-io/vb-test/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/balena-io/vb-test/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/balena-io/vb-test/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/balena-io/vb-test/blob/master/balena.yml"
+  }
+}

--- a/test/integration/webhooks/github/push-to-open-pr/stubs/1/repos-balena-io-vb-test-contents-balena-yml-ref-7792-c-35-b-172-a-6-ee-7-b-155-c-471-a-36-c-3-cda-1-ef-649-f-6.json
+++ b/test/integration/webhooks/github/push-to-open-pr/stubs/1/repos-balena-io-vb-test-contents-balena-yml-ref-7792-c-35-b-172-a-6-ee-7-b-155-c-471-a-36-c-3-cda-1-ef-649-f-6.json
@@ -1,0 +1,18 @@
+{
+  "name": "balena.yml",
+  "path": "balena.yml",
+  "sha": "47db3633a32ac11cf6916f21909828b978c35b0d",
+  "size": 100,
+  "url": "https://api.github.com/repos/balena-io/vb-test/contents/balena.yml?ref=master",
+  "html_url": "https://github.com/balena-io/vb-test/blob/master/balena.yml",
+  "git_url": "https://api.github.com/repos/balena-io/vb-test/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+  "download_url": "https://raw.githubusercontent.com/balena-io/vb-test/master/balena.yml?token=AKZ6GNKLG3RHH4A1231324JSKHL",
+  "type": "file",
+  "content": "YnVpbGQtdmFyaWFibGVzOgogIGdsb2JhbDoKICAgIC0gU0VOVFJZX0RTTl9V\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/balena-io/vb-test/contents/balena.yml?ref=master",
+    "git": "https://api.github.com/repos/balena-io/vb-test/git/blobs/47db3633a32ac11cf6916f21909828b978c35b0d",
+    "html": "https://github.com/balena-io/vb-test/blob/master/balena.yml"
+  }
+}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add missing integration test stubs for `balena.yml` [GET contents](https://docs.github.com/en/rest/reference/repos#get-repository-content) API calls.

This was causing numerous `Stub not found` warnings in test logs, adding unnecessary noise. Not to mention, we *should* be stubbing all GitHub API requests made during translate tests.