### PR TITLE
Remove redundant meta relationships

### DIFF
--- a/lib/cards/contrib/issue.ts
+++ b/lib/cards/contrib/issue.ts
@@ -6,24 +6,17 @@
 
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
-const SLUG = 'issue';
-
 export default function ({
 	mixin,
 	withEvents,
-	withRelationships,
 	uiSchemaDef,
 }: {
 	mixin: any;
 	withEvents?: any;
-	withRelationships?: any;
 	uiSchemaDef?: any;
 }): ContractDefinition {
-	return mixin(
-		withEvents,
-		withRelationships(SLUG),
-	)({
-		slug: SLUG,
+	return mixin(withEvents)({
+		slug: 'issue',
 		name: 'GitHub Issue',
 		type: 'type@1.0.0',
 		data: {

--- a/lib/cards/contrib/repository.ts
+++ b/lib/cards/contrib/repository.ts
@@ -6,19 +6,13 @@
 
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
-const SLUG = 'repository';
-
 export default function ({
-	mixin,
-	withRelationships,
 	uiSchemaDef,
 }: {
-	mixin: any;
-	withRelationships?: any;
 	uiSchemaDef?: any;
 }): ContractDefinition {
-	return mixin(withRelationships(SLUG, ['thread']))({
-		slug: SLUG,
+	return {
+		slug: 'repository',
 		name: 'Github Repository',
 		type: 'type@1.0.0',
 		markers: [],
@@ -65,5 +59,5 @@ export default function ({
 			},
 			indexed_fields: [['data.name']],
 		},
-	});
+	};
 }


### PR DESCRIPTION
hese are now materialized automatically on the front-end using link constraints.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>