### PR TITLE
Fix bug where closing a PR would not sync data correctly

### DIFF
--- a/test/integration/webhooks/github/pr-approve-merge/expected.json
+++ b/test/integration/webhooks/github/pr-approve-merge/expected.json
@@ -28,8 +28,8 @@
       "description": "Signed-off-by: Juan Cruz Viotti <juan@resin.io>",
       "status": "closed",
       "archived": false,
-      "merged_at": null,
-      "closed_at": null,
+      "closed_at": "2018-10-10T10:44:15Z",
+      "merged_at": "2018-10-10T10:44:15Z",
       "contract": null,
       "$transformer": {
         "artifactReady": "803d0ccc315e606fe8d00cf52138de654c3f35aa"
@@ -98,7 +98,29 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T10:44:15.000Z",
+        "timestamp": "2018-10-10T10:34:00.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
+        "payload": [
+          {
+            "op": "replace",
+            "path": "/data/merged_at",
+            "value": "2018-10-10T10:44:15Z"
+          },
+          {
+            "op": "replace",
+            "path": "/data/closed_at",
+            "value": "2018-10-10T10:44:15Z"
+          }
+        ]
+      }
+    },
+    {
+      "active": true,
+      "capabilities": [],
+      "data": {
         "actor": {
           "active": true,
           "slug": "user-jviotti"
@@ -109,8 +131,17 @@
             "path": "/data/status",
             "value": "closed"
           }
-        ]
-      }
+        ],
+        "target": "52518fd8-3065-479a-bbf4-a37df5f2a6ff",
+        "timestamp": "2018-10-10T10:44:15.000Z"
+      },
+      "id": "1161128f-faaa-479f-9a62-2c18115c00d0",
+      "loop": null,
+      "name": null,
+      "requires": [],
+      "tags": [],
+      "type": "update@1.0.0",
+      "version": "1.0.0"
     }
   ]
 }

--- a/test/integration/webhooks/github/pr-open-close/expected.json
+++ b/test/integration/webhooks/github/pr-open-close/expected.json
@@ -29,7 +29,7 @@
       "status": "closed",
       "archived": false,
       "merged_at": null,
-      "closed_at": null,
+      "closed_at": "2018-10-10T09:11:51Z",
       "contract": null,
       "$transformer": {
         "artifactReady": "803d0ccc315e606fe8d00cf52138de654c3f35aa"
@@ -98,7 +98,26 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-10-10T09:11:51.000Z",
+        "timestamp": "2018-10-10T09:09:36.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-jviotti"
+        },
+        "payload": [
+          {
+            "op": "replace",
+            "path": "/data/closed_at",
+            "value": "2018-10-10T09:11:51Z"
+          }
+        ],
+        "target": "51d731e4-693a-4456-a113-521c07000a54"
+      },
+      "id": "bbea47b7-c334-4804-a6f3-1980fe3a3bb4",
+      "name": null
+    }, {
+      "active": true,
+      "capabilities": [],
+      "data": {
         "actor": {
           "active": true,
           "slug": "user-jviotti"
@@ -109,8 +128,16 @@
             "path": "/data/status",
             "value": "closed"
           }
-        ]
-      }
+        ],
+        "target": "51d731e4-693a-4456-a113-521c07000a54",
+        "timestamp": "2018-10-10T09:11:51.000Z"
+      },
+      "loop": null,
+      "name": null,
+      "requires": [],
+      "tags": [],
+      "type": "update@1.0.0",
+      "version": "1.0.0"
     }
   ]
 }

--- a/test/integration/webhooks/github/pr-open-from-fork/expected.json
+++ b/test/integration/webhooks/github/pr-open-from-fork/expected.json
@@ -29,7 +29,7 @@
       "status": "closed",
       "archived": false,
       "merged_at": null,
-      "closed_at": null,
+      "closed_at": "2018-12-18T10:34:55Z",
       "contract": null,
       "$transformer": {
         "artifactReady": "61c13a539195aece8506f4f7eb1c01765e935891"
@@ -98,7 +98,24 @@
       "requires": [],
       "capabilities": [],
       "data": {
-        "timestamp": "2018-12-18T10:34:55.000Z",
+        "timestamp": "2018-12-18T10:30:19.000Z",
+        "actor": {
+          "active": true,
+          "slug": "user-nazrhom"
+        },
+        "payload": [
+          {
+            "op": "replace",
+            "path": "/data/closed_at",
+            "value": "2018-12-18T10:34:55Z"
+          }
+        ]
+      }
+    },
+    {
+      "active": true,
+      "capabilities": [],
+      "data": {
         "actor": {
           "active": true,
           "slug": "user-nazrhom"
@@ -109,8 +126,16 @@
             "path": "/data/status",
             "value": "closed"
           }
-        ]
-      }
+        ],
+        "target": "c99d4dd9-8623-4e3c-bb2c-12e49c02dd8c",
+        "timestamp": "2018-12-18T10:34:55.000Z"
+      },
+      "loop": null,
+      "name": null,
+      "requires": [],
+      "tags": [],
+      "type": "update@1.0.0",
+      "version": "1.0.0"
     }
   ]
 }


### PR DESCRIPTION
When closing a PR, the codepath taken would exit early, and not fill in
important information such as `merged_at` and `closed_at`.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>