### PR TITLE
Add new github-org contract type

### DIFF
--- a/lib/cards/contrib/github-org.ts
+++ b/lib/cards/contrib/github-org.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+
+const githubOrg: ContractDefinition = {
+	slug: 'github-org',
+	name: 'GitHub Organization',
+	type: 'type@1.0.0',
+	data: {
+		schema: {
+			type: 'object',
+			properties: {
+				name: {
+					type: 'string',
+					fullTextSearch: true,
+				},
+				data: {
+					type: 'object',
+					properties: {
+						description: {
+							type: 'string',
+							format: 'markdown',
+						},
+					},
+				},
+			},
+			required: ['name'],
+		},
+	},
+};
+
+export default githubOrg;

--- a/lib/cards/index.ts
+++ b/lib/cards/index.ts
@@ -7,6 +7,7 @@
 import viewAllIssues from './balena/view-all-issues.json';
 import checkRun from './contrib/check-run';
 import commit from './contrib/commit';
+import githubOrg from './contrib/github-org';
 import issue from './contrib/issue';
 import installation from './contrib/installation';
 import pullRequest from './contrib/pull-request';
@@ -20,6 +21,7 @@ import triggeredActionSupportClosedPullRequestReopen from './contrib/triggered-a
 export default [
 	checkRun,
 	commit,
+	githubOrg,
 	issue,
 	installation,
 	pullRequest,


### PR DESCRIPTION
In due course this type will be used to sync GitHub orgs with JF. But for now we just need this type to be defined and we can manually create instances of this type.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>