### PR TITLE
Update evaluted fields to reference 'contract' instead of 'this'

### DIFF
--- a/lib/cards/contrib/commit.ts
+++ b/lib/cards/contrib/commit.ts
@@ -58,8 +58,8 @@ export default function ({
 										description: 'all downstream contracts are mergeable',
 										type: 'boolean',
 										$$formula:
-											'this.links["was built into"].length > 0 && ' +
-											'EVERY(this.links["was built into"], "data.$transformer.mergeable")',
+											'contract.links["was built into"].length > 0 && ' +
+											'EVERY(contract.links["was built into"], "data.$transformer.mergeable")',
 										readOnly: true,
 										default: false,
 									},
@@ -67,9 +67,9 @@ export default function ({
 										description: 'PR is merged',
 										type: 'boolean',
 										$$formula:
-											'this.links["is attached to PR"].length > 0 && ' +
-											'this.links["is attached to PR"][0].data.merged_at &&' +
-											'this.links["is attached to PR"][0].data.head.sha === this.data.head.sha',
+											'contract.links["is attached to PR"].length > 0 && ' +
+											'contract.links["is attached to PR"][0].data.merged_at && ' +
+											'contract.links["is attached to PR"][0].data.head.sha === contract.data.head.sha',
 										readOnly: true,
 										default: false,
 									},

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@balena/jellyfish-core": "^5.0.7",
     "@balena/jellyfish-environment": "^4.3.10",
     "@balena/jellyfish-plugin-default": "^19.0.0",
-    "@balena/jellyfish-test-harness": "^6.0.5",
+    "@balena/jellyfish-test-harness": "^6.0.45",
     "@balena/jellyfish-types": "^0.8.5",
     "@balena/lint": "^6.1.1",
     "@types/bluebird": "^3.5.36",


### PR DESCRIPTION
Also update jellyfish-test-harness dependency - pulls in latest jellyscript.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>