### PR TITLE
Add data.mirrors indexes

### DIFF
--- a/lib/cards/contrib/issue.ts
+++ b/lib/cards/contrib/issue.ts
@@ -112,6 +112,7 @@ export default function ({
 				},
 			},
 			slices: ['properties.data.properties.status'],
+			indexed_fields: [['data.mirrors']],
 		},
 	});
 }

--- a/lib/cards/contrib/pull-request.ts
+++ b/lib/cards/contrib/pull-request.ts
@@ -147,7 +147,7 @@ export default function ({
 				},
 			},
 			slices: ['properties.data.properties.status'],
-			indexed_fields: [['data.status']],
+			indexed_fields: [['data.status'], ['data.mirrors']],
 		},
 	});
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add `data.mirrors` indexed fields for a couple cards.

Depends on:
- https://github.com/product-os/jellyfish-core/pull/866