### PR TITLE
Mark loop field as required on repository contract schema

### DIFF
--- a/lib/cards/contrib/repository.ts
+++ b/lib/cards/contrib/repository.ts
@@ -24,6 +24,9 @@ export default function ({
 						type: 'string',
 						fullTextSearch: true,
 					},
+					loop: {
+						type: 'string',
+					},
 					data: {
 						type: 'object',
 						properties: {
@@ -43,7 +46,7 @@ export default function ({
 						},
 					},
 				},
-				required: ['data'],
+				required: ['loop', 'data'],
 			},
 			uiSchema: {
 				fields: {

--- a/test/integration/fixtures/index.ts
+++ b/test/integration/fixtures/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export { default as loopBalenaIo } from './loop-balena-io.json';
+
+export const createGitHubOrg = (name, loop = 'loop-balena-io@1.0.0') => {
+	return {
+		data: {
+			mirrors: [`https://github.com/${name}`],
+		},
+		loop,
+		name: `github org ${name}`,
+		slug: `github-org-${name}`,
+		type: 'github-org@1.0.0',
+		version: '1.0.0',
+	};
+};

--- a/test/integration/fixtures/loop-balena-io.json
+++ b/test/integration/fixtures/loop-balena-io.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "roles": [
+      "loop"
+    ]
+  },
+  "loop": null,
+  "name": "balena-io",
+  "slug": "loop-balena-io",
+  "type": "loop@1.0.0",
+  "version": "1.0.0"
+}

--- a/test/integration/github-translate.spec.ts
+++ b/test/integration/github-translate.spec.ts
@@ -12,8 +12,33 @@ import jwt from 'jsonwebtoken';
 import nock from 'nock';
 import { GitHubPlugin } from '../../lib';
 import webhooks from './webhooks/github';
+import { createGitHubOrg, loopBalenaIo } from './fixtures';
 
 const TOKEN = defaultEnvironment.integration.github;
+
+const testGitHubOrgs = [
+	'loop-os',
+	'loop-os-staging',
+	'Codertocat',
+	'resin-io',
+	'balena-io',
+	'nazrhom',
+];
+
+const loadGithubOrgs = async (context) => {
+	await context.jellyfish.insertCard(
+		context.context,
+		context.session,
+		loopBalenaIo,
+	);
+	for (const gitHubOrgName of testGitHubOrgs) {
+		await context.jellyfish.insertCard(
+			context.context,
+			context.session,
+			createGitHubOrg(gitHubOrgName),
+		);
+	}
+};
 
 const accessTokenNock = async () => {
 	if (TOKEN.api && TOKEN.key) {
@@ -71,10 +96,12 @@ syncIntegrationScenario.run(
 			'gh-push',
 			'check-run',
 			'commit',
+			'github-org',
 		],
 		scenarios: webhooks,
 		baseUrl: 'https://api.github.com',
 		stubRegex: /.*/,
+		before: loadGithubOrgs,
 		beforeEach: accessTokenNock,
 		source: 'github',
 		options: {

--- a/test/integration/webhooks/github/moving-repo-between-orgs/expected.json
+++ b/test/integration/webhooks/github/moving-repo-between-orgs/expected.json
@@ -4,7 +4,7 @@
     "type": "repository@1.0.0",
     "version": "1.0.0",
     "active": true,
-    "loop": null,
+    "loop": "loop-balena-io@1.0.0",
     "tags": [],
     "requires": [],
     "capabilities": [],

--- a/test/integration/webhooks/github/open-pr-and-create-repos/expected.json
+++ b/test/integration/webhooks/github/open-pr-and-create-repos/expected.json
@@ -4,7 +4,7 @@
     "type":  "repository@1.0.0",
     "slug":  "repository-resin-io-jellyfish",
     "active": true,
-    "loop": null,
+    "loop": "loop-balena-io@1.0.0",
     "capabilities": [ ],
     "data": {
       "git_url":  "git://github.com/resin-io/jellyfish.git",
@@ -35,6 +35,7 @@
         "payload": {
           "name":  "resin-io/jellyfish",
           "type":  "repository@1.0.0",
+          "loop": "loop-balena-io@1.0.0",
           "active": true,
           "capabilities": [ ],
           "data": {


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

TO RESOLVE: 
1. Currently there are 390 repository contracts not assigned to a loop as they are _forked_ (so the 'owner' does not correspond to any `github_org` contract in JF). These would cause problems if loop is a required field.
1. if a _new_ org is synced with Jellyfish and then a repo in that org is synced, we will not have a corresponding `github-org` contract to look up the loop to assign to the repo. So the sync will fail.