### PR TITLE
Add support-thread  triggered action tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@balena/jellyfish-environment": "^5.0.1",
     "@balena/jellyfish-plugin-default": "^21.1.0",
     "@balena/jellyfish-plugin-product-os": "^2.7.1",
-    "@balena/jellyfish-test-harness": "^7.3.1",
+    "@balena/jellyfish-test-harness": "^7.3.4",
     "@balena/jellyfish-types": "^1.1.0",
     "@balena/lint": "^6.1.1",
     "@types/bluebird": "^3.5.36",

--- a/test/integration/cards/contrib/triggered-action-support-closed-issue-reopen.spec.ts
+++ b/test/integration/cards/contrib/triggered-action-support-closed-issue-reopen.spec.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ActionLibrary = require('@balena/jellyfish-action-library');
+import { defaultEnvironment } from '@balena/jellyfish-environment';
+import { DefaultPlugin } from '@balena/jellyfish-plugin-default';
+import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { integrationHelpers } from '@balena/jellyfish-test-harness';
+import _ from 'lodash';
+import { GitHubPlugin } from '../../../../lib';
+
+let ctx: integrationHelpers.IntegrationTestContext;
+let user: any = {};
+let userSession: string = '';
+let username: string = '';
+
+const [owner, repo] =
+	defaultEnvironment.test.integration.github.repo.split('/');
+const repository = {
+	owner: owner.trim(),
+	repo: repo.trim(),
+};
+
+beforeAll(async () => {
+	ctx = await integrationHelpers.before([
+		DefaultPlugin,
+		ActionLibrary,
+		ProductOsPlugin,
+		GitHubPlugin,
+	]);
+
+	username = ctx.generateRandomID();
+	const createdUser = await ctx.createUser(username);
+	user = createdUser.contract;
+	userSession = createdUser.session;
+});
+
+afterAll(() => {
+	return integrationHelpers.after(ctx);
+});
+
+test('should re-open a closed support thread if an attached issue is closed', async () => {
+	const title = `Test Issue ${username}`;
+	const issue = await ctx.createIssue(user.id, userSession, title, {
+		status: 'open',
+		description: 'Foo bar',
+		repository: `${repository.owner}/${repository.repo}`,
+	});
+
+	const supportThread = await ctx.createSupportThread(
+		user.id,
+		userSession,
+		'test subject',
+		{
+			product: 'test-product',
+			inbox: 'S/Paid_Support',
+			status: 'closed',
+		},
+	);
+
+	await ctx.createLink(
+		user.id,
+		userSession,
+		supportThread,
+		issue,
+		'support thread is attached to issue',
+		'issue has attached support thread',
+	);
+
+	// Update issue status to closed
+	await ctx.worker.patchCard(
+		ctx.context,
+		userSession,
+		ctx.worker.typeContracts[issue.type],
+		{
+			attachEvents: true,
+			actor: user.id,
+		},
+		issue,
+		[
+			{
+				op: 'replace',
+				path: '/data/status',
+				value: 'closed',
+			},
+		],
+	);
+	await ctx.flushAll(userSession);
+
+	// Wait for the support thread to be re-opened
+	await ctx.waitForMatch({
+		type: 'object',
+		required: ['id', 'data'],
+		properties: {
+			id: {
+				const: supportThread.id,
+			},
+			data: {
+				type: 'object',
+				required: ['status'],
+				properties: {
+					status: {
+						const: 'open',
+					},
+				},
+			},
+		},
+	});
+});

--- a/test/integration/cards/contrib/triggered-action-support-closed-pull-request-reopen.spec.ts
+++ b/test/integration/cards/contrib/triggered-action-support-closed-pull-request-reopen.spec.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import ActionLibrary = require('@balena/jellyfish-action-library');
+import { DefaultPlugin } from '@balena/jellyfish-plugin-default';
+import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { integrationHelpers } from '@balena/jellyfish-test-harness';
+import _ from 'lodash';
+import { GitHubPlugin } from '../../../../lib';
+
+let ctx: integrationHelpers.IntegrationTestContext;
+let user: any = {};
+let userSession: string = '';
+let username: string = '';
+
+beforeAll(async () => {
+	ctx = await integrationHelpers.before([
+		DefaultPlugin,
+		ActionLibrary,
+		ProductOsPlugin,
+		GitHubPlugin,
+	]);
+
+	username = ctx.generateRandomID();
+	const createdUser = await ctx.createUser(username);
+	user = createdUser.contract;
+	userSession = createdUser.session;
+});
+
+afterAll(() => {
+	return integrationHelpers.after(ctx);
+});
+
+test('should re-open a closed support thread if an attached issue is closed', async () => {
+	const title = `Test Issue ${username}`;
+	const pullRequest = await ctx.createContract(
+		user.id,
+		userSession,
+		'pull-request@1.0.0',
+		title,
+		{
+			status: 'open',
+		},
+	);
+
+	const supportThread = await ctx.createSupportThread(
+		user.id,
+		userSession,
+		'test subject',
+		{
+			status: 'closed',
+		},
+	);
+
+	await ctx.createLink(
+		user.id,
+		userSession,
+		supportThread,
+		pullRequest,
+		'support thread is attached to pull request',
+		'pull request has attached support thread',
+	);
+
+	// Update issue status to closed
+	await ctx.worker.patchCard(
+		ctx.context,
+		userSession,
+		ctx.worker.typeContracts[pullRequest.type],
+		{
+			attachEvents: true,
+			actor: user.id,
+		},
+		pullRequest,
+		[
+			{
+				op: 'replace',
+				path: '/data/status',
+				value: 'closed',
+			},
+		],
+	);
+	await ctx.flushAll(userSession);
+
+	// Wait for the support thread to be re-opened
+	await ctx.waitForMatch({
+		type: 'object',
+		required: ['id', 'data'],
+		properties: {
+			id: {
+				const: supportThread.id,
+			},
+			data: {
+				type: 'object',
+				required: ['status'],
+				properties: {
+					status: {
+						const: 'open',
+					},
+				},
+			},
+		},
+	});
+});


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Move a number of `support-thread` related triggered action tests from the main repo: https://github.com/product-os/jellyfish/blob/d054a2c25d7c4a812ffc7f2c57761c5b9175c882/test/e2e/server/support.spec.js