### PR TITLE
Remove `artifactReady` schema from `commit` contract.

### DIFF
--- a/lib/contracts/commit.ts
+++ b/lib/contracts/commit.ts
@@ -44,9 +44,6 @@ export const commit: ContractDefinition = cardMixins.mixin(
 						$transformer: {
 							type: 'object',
 							properties: {
-								artifactReady: {
-									type: 'boolean',
-								},
 								mergeable: {
 									description: 'all downstream contracts are mergeable',
 									type: 'string',


### PR DESCRIPTION
`artifactReady` can be set to a string by transformer worker. See: https://github.com/product-os/transformer-worker/blob/3c4dbfbd361dca7e7acd1d6599511f96af2d43ad/transformer-runner/src/jellyfish.ts#L170