### PR TITLE
Add relationship definitions

### DIFF
--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -5,6 +5,24 @@ import { githubOrg } from './github-org';
 import { issue } from './issue';
 import { pullRequest } from './pull-request';
 import { push } from './push';
+import { relationshipBrainstormTopicHasAttachedIssue } from './relationship-brainstorm-topic-has-attached-issue';
+import { relationshipCommitHasAttachedCheckRun } from './relationship-commit-has-attached-check-run';
+import { relationshipCommitIsAttachedToPullRequest } from './relationship-commit-is-attached-to-pull-request';
+import { relationshipImprovementIsAttachedToIssue } from './relationship-improvement-is-attached-to-issue';
+import { relationshipImprovementIsAttachedToPullRequest } from './relationship-improvement-is-attached-to-pull-request';
+import { relationshipIssueHasAttachedPattern } from './relationship-issue-has-attached-pattern';
+import { relationshipIssueIsAttachedToUserFeedback } from './relationship-issue-is-attached-to-user-feedback';
+import { relationshipIssueIsOwnedByUser } from './relationship-issue-is-owned-by-user';
+import { relationshipLoopHasRepository } from './relationship-loop-has-repository';
+import { relationshipMessageIsAttachedToIssue } from './relationship-message-is-attached-to-issue';
+import { relationshipMilestoneIsAttachedToIssue } from './relationship-milestone-is-attached-to-issue';
+import { relationshipMilestoneIsAttachedToPullRequest } from './relationship-milestone-is-attached-to-pull-request';
+import { relationshipPullRequestHasAttachedPattern } from './relationship-pull-request-has-attached-pattern';
+import { relationshipRepositoryHasThread } from './relationship-repository-has-thread';
+import { relationshipRepositoryUsesRepository } from './relationship-repository-uses-repository';
+import { relationshipSalesThreadIsAttachedToIssue } from './relationship-sales-thread-is-attached-to-issue';
+import { relationshipSupportThreadIsAttachedToIssue } from './relationship-support-thread-is-attached-to-issue';
+import { relationshipSupportThreadIsAttachedToPullRequest } from './relationship-support-thread-is-attached-to-pull-request';
 import { repository } from './repository';
 import { triggeredActionConcludeCheckRun } from './triggered-action-conclude-check-run';
 import { triggeredActionFailedCheckRun } from './triggered-action-failed-check-run';
@@ -23,6 +41,24 @@ export const contracts: ContractDefinition[] = [
 	issue,
 	pullRequest,
 	push,
+	relationshipBrainstormTopicHasAttachedIssue,
+	relationshipCommitHasAttachedCheckRun,
+	relationshipCommitIsAttachedToPullRequest,
+	relationshipImprovementIsAttachedToIssue,
+	relationshipImprovementIsAttachedToPullRequest,
+	relationshipIssueHasAttachedPattern,
+	relationshipIssueIsAttachedToUserFeedback,
+	relationshipIssueIsOwnedByUser,
+	relationshipLoopHasRepository,
+	relationshipMessageIsAttachedToIssue,
+	relationshipMilestoneIsAttachedToIssue,
+	relationshipMilestoneIsAttachedToPullRequest,
+	relationshipPullRequestHasAttachedPattern,
+	relationshipRepositoryHasThread,
+	relationshipRepositoryUsesRepository,
+	relationshipSalesThreadIsAttachedToIssue,
+	relationshipSupportThreadIsAttachedToIssue,
+	relationshipSupportThreadIsAttachedToPullRequest,
 	repository,
 	triggeredActionConcludeCheckRun,
 	triggeredActionFailedCheckRun,

--- a/lib/contracts/relationship-brainstorm-topic-has-attached-issue.ts
+++ b/lib/contracts/relationship-brainstorm-topic-has-attached-issue.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipBrainstormTopicHasAttachedIssue: RelationshipContractDefinition =
+	{
+		slug: 'relationship-brainstorm-topic-has-attached-issue',
+		type: 'relationship@1.0.0',
+		name: 'has attached',
+		data: {
+			inverseName: 'is attached to',
+			title: 'GitHub issue',
+			inverseTitle: 'Brainstorm topic',
+			from: {
+				type: 'brainstorm-topic',
+			},
+			to: {
+				type: 'issue',
+			},
+		},
+	};

--- a/lib/contracts/relationship-commit-has-attached-check-run.ts
+++ b/lib/contracts/relationship-commit-has-attached-check-run.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipCommitHasAttachedCheckRun: RelationshipContractDefinition =
+	{
+		slug: 'relationship-commit-has-attached-check-run',
+		type: 'relationship@1.0.0',
+		name: 'has attached',
+		data: {
+			inverseName: 'is attached to',
+			title: 'Check Run',
+			inverseTitle: 'Commit',
+			from: {
+				type: 'commit',
+			},
+			to: {
+				type: 'check-run',
+			},
+		},
+	};

--- a/lib/contracts/relationship-commit-is-attached-to-pull-request.ts
+++ b/lib/contracts/relationship-commit-is-attached-to-pull-request.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipCommitIsAttachedToPullRequest: RelationshipContractDefinition =
+	{
+		slug: 'relationship-commit-is-attached-to-pull-request',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached',
+			title: 'Pull Request',
+			inverseTitle: 'Commit',
+			from: {
+				type: 'commit',
+			},
+			to: {
+				type: 'pull-request',
+			},
+		},
+	};

--- a/lib/contracts/relationship-improvement-is-attached-to-issue.ts
+++ b/lib/contracts/relationship-improvement-is-attached-to-issue.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipImprovementIsAttachedToIssue: RelationshipContractDefinition =
+	{
+		slug: 'relationship-improvement-is-attached-to-issue',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached',
+			title: 'GitHub issue',
+			inverseTitle: 'Improvement',
+			from: {
+				type: 'improvement',
+			},
+			to: {
+				type: 'issue',
+			},
+		},
+	};

--- a/lib/contracts/relationship-improvement-is-attached-to-pull-request.ts
+++ b/lib/contracts/relationship-improvement-is-attached-to-pull-request.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipImprovementIsAttachedToPullRequest: RelationshipContractDefinition =
+	{
+		slug: 'relationship-improvement-is-attached-to-pull-request',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached',
+			title: 'Pull request',
+			inverseTitle: 'Improvement',
+			from: {
+				type: 'improvement',
+			},
+			to: {
+				type: 'pull-request',
+			},
+		},
+	};

--- a/lib/contracts/relationship-issue-has-attached-pattern.ts
+++ b/lib/contracts/relationship-issue-has-attached-pattern.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipIssueHasAttachedPattern: RelationshipContractDefinition =
+	{
+		slug: 'relationship-issue-has-attached-pattern',
+		type: 'relationship@1.0.0',
+		name: 'has attached',
+		data: {
+			inverseName: 'is attached to',
+			title: 'Pattern',
+			inverseTitle: 'GitHub issue',
+			from: {
+				type: 'issue',
+			},
+			to: {
+				type: 'pattern',
+			},
+		},
+	};

--- a/lib/contracts/relationship-issue-is-attached-to-user-feedback.ts
+++ b/lib/contracts/relationship-issue-is-attached-to-user-feedback.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipIssueIsAttachedToUserFeedback: RelationshipContractDefinition =
+	{
+		slug: 'relationship-issue-is-attached-to-user-feedback',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached',
+			title: 'User feedback',
+			inverseTitle: 'GitHub issue',
+			from: {
+				type: 'issue',
+			},
+			to: {
+				type: 'user-feedback',
+			},
+		},
+	};

--- a/lib/contracts/relationship-issue-is-owned-by-user.ts
+++ b/lib/contracts/relationship-issue-is-owned-by-user.ts
@@ -1,0 +1,18 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipIssueIsOwnedByUser: RelationshipContractDefinition = {
+	slug: 'relationship-issue-is-owned-by-user',
+	type: 'relationship@1.0.0',
+	name: 'is owned by',
+	data: {
+		inverseName: 'is owner of',
+		title: 'Owner',
+		inverseTitle: 'Owned issue',
+		from: {
+			type: 'issue',
+		},
+		to: {
+			type: 'user',
+		},
+	},
+};

--- a/lib/contracts/relationship-loop-has-repository.ts
+++ b/lib/contracts/relationship-loop-has-repository.ts
@@ -1,0 +1,18 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipLoopHasRepository: RelationshipContractDefinition = {
+	slug: 'relationship-loop-has-repository',
+	type: 'relationship@1.0.0',
+	name: 'has',
+	data: {
+		inverseName: 'is used by',
+		title: 'Products',
+		inverseTitle: 'Loop',
+		from: {
+			type: 'loop',
+		},
+		to: {
+			type: 'repository',
+		},
+	},
+};

--- a/lib/contracts/relationship-message-is-attached-to-issue.ts
+++ b/lib/contracts/relationship-message-is-attached-to-issue.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipMessageIsAttachedToIssue: RelationshipContractDefinition =
+	{
+		slug: 'relationship-message-is-attached-to-issue',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached element',
+			title: 'Message',
+			inverseTitle: 'Issue',
+			from: {
+				type: 'message',
+			},
+			to: {
+				type: 'issue',
+			},
+		},
+	};

--- a/lib/contracts/relationship-milestone-is-attached-to-issue.ts
+++ b/lib/contracts/relationship-milestone-is-attached-to-issue.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipMilestoneIsAttachedToIssue: RelationshipContractDefinition =
+	{
+		slug: 'relationship-milestone-is-attached-to-issue',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached',
+			title: 'GitHub issue',
+			inverseTitle: 'Milestone',
+			from: {
+				type: 'milestone',
+			},
+			to: {
+				type: 'issue',
+			},
+		},
+	};

--- a/lib/contracts/relationship-milestone-is-attached-to-pull-request.ts
+++ b/lib/contracts/relationship-milestone-is-attached-to-pull-request.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipMilestoneIsAttachedToPullRequest: RelationshipContractDefinition =
+	{
+		slug: 'relationship-milestone-is-attached-to-pull-request',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached',
+			title: 'Pull request',
+			inverseTitle: 'Milestone',
+			from: {
+				type: 'milestone',
+			},
+			to: {
+				type: 'pull-request',
+			},
+		},
+	};

--- a/lib/contracts/relationship-pull-request-has-attached-pattern.ts
+++ b/lib/contracts/relationship-pull-request-has-attached-pattern.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipPullRequestHasAttachedPattern: RelationshipContractDefinition =
+	{
+		slug: 'relationship-pull-request-has-attached-pattern',
+		type: 'relationship@1.0.0',
+		name: 'has attached',
+		data: {
+			inverseName: 'is attached to',
+			title: 'Pattern',
+			inverseTitle: 'Pull request',
+			from: {
+				type: 'pull-request',
+			},
+			to: {
+				type: 'pattern',
+			},
+		},
+	};

--- a/lib/contracts/relationship-repository-has-thread.ts
+++ b/lib/contracts/relationship-repository-has-thread.ts
@@ -1,0 +1,18 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipRepositoryHasThread: RelationshipContractDefinition = {
+	slug: 'relationship-repository-has-thread',
+	type: 'relationship@1.0.0',
+	name: 'has',
+	data: {
+		inverseName: 'is of',
+		title: 'Thread',
+		inverseTitle: 'Repository',
+		from: {
+			type: 'repository',
+		},
+		to: {
+			type: 'thread',
+		},
+	},
+};

--- a/lib/contracts/relationship-repository-uses-repository.ts
+++ b/lib/contracts/relationship-repository-uses-repository.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipRepositoryUsesRepository: RelationshipContractDefinition =
+	{
+		slug: 'relationship-repository-uses-repository',
+		type: 'relationship@1.0.0',
+		name: 'uses',
+		data: {
+			inverseName: 'is used by',
+			title: 'Uses product',
+			inverseTitle: 'Used by product',
+			from: {
+				type: 'repository',
+			},
+			to: {
+				type: 'repository',
+			},
+		},
+	};

--- a/lib/contracts/relationship-sales-thread-is-attached-to-issue.ts
+++ b/lib/contracts/relationship-sales-thread-is-attached-to-issue.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipSalesThreadIsAttachedToIssue: RelationshipContractDefinition =
+	{
+		slug: 'relationship-sales-thread-is-attached-to-issue',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached',
+			title: 'GitHub issue',
+			inverseTitle: 'Sales thread',
+			from: {
+				type: 'sales-thread',
+			},
+			to: {
+				type: 'issue',
+			},
+		},
+	};

--- a/lib/contracts/relationship-support-thread-is-attached-to-issue.ts
+++ b/lib/contracts/relationship-support-thread-is-attached-to-issue.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipSupportThreadIsAttachedToIssue: RelationshipContractDefinition =
+	{
+		slug: 'relationship-support-thread-is-attached-to-issue',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached',
+			title: 'GitHub issue',
+			inverseTitle: 'Support thread',
+			from: {
+				type: 'support-thread',
+			},
+			to: {
+				type: 'issue',
+			},
+		},
+	};

--- a/lib/contracts/relationship-support-thread-is-attached-to-pull-request.ts
+++ b/lib/contracts/relationship-support-thread-is-attached-to-pull-request.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipSupportThreadIsAttachedToPullRequest: RelationshipContractDefinition =
+	{
+		slug: 'relationship-support-thread-is-attached-to-pull-request',
+		type: 'relationship@1.0.0',
+		name: 'is attached to',
+		data: {
+			inverseName: 'has attached',
+			title: 'Pull request',
+			inverseTitle: 'Support thread',
+			from: {
+				type: 'support-thread',
+			},
+			to: {
+				type: 'pull-request',
+			},
+		},
+	};


### PR DESCRIPTION
Add relationships defined between contract types in the module, or between contract types in the module and its dependencies

Change-type: patch
Signed-off-by: Ramiro Gonzalez <ramiro.gonzalez@balena.io>