### PR TITLE
Improve matching of mirror triggers

### DIFF
--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -32,6 +32,7 @@ import { triggeredActionConcludeCheckRun } from './triggered-action-conclude-che
 import { triggeredActionFailedCheckRun } from './triggered-action-failed-check-run';
 import { triggeredActionGitHubIssueLink } from './triggered-action-github-issue-link';
 import { triggeredActionInProgressCheckRun } from './triggered-action-in-progress-check-run';
+import { triggeredActionIntegrationGitHubMirrorEntities } from './triggered-action-integration-github-mirror-entities';
 import { triggeredActionIntegrationGitHubMirrorEvent } from './triggered-action-integration-github-mirror-event';
 import { triggeredActionSupportClosedIssueReopen } from './triggered-action-support-closed-issue-reopen';
 import { triggeredActionSupportClosedPullRequestReopen } from './triggered-action-support-closed-pull-request-reopen';
@@ -72,6 +73,7 @@ export const contracts: ContractDefinition[] = [
 	triggeredActionFailedCheckRun,
 	triggeredActionGitHubIssueLink,
 	triggeredActionInProgressCheckRun,
+	triggeredActionIntegrationGitHubMirrorEntities,
 	triggeredActionIntegrationGitHubMirrorEvent,
 	triggeredActionSupportClosedIssueReopen,
 	triggeredActionSupportClosedPullRequestReopen,

--- a/lib/contracts/triggered-action-integration-github-mirror-entities.ts
+++ b/lib/contracts/triggered-action-integration-github-mirror-entities.ts
@@ -1,0 +1,32 @@
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+
+export const triggeredActionIntegrationGitHubMirrorEntities: ContractDefinition =
+	{
+		slug: 'triggered-action-integration-github-mirror-entities',
+		type: 'triggered-action@1.0.0',
+		name: 'Triggered action for mirroring GitHub entities',
+		markers: [],
+		data: {
+			filter: {
+				type: 'object',
+				required: ['type'],
+				properties: {
+					type: {
+						type: 'string',
+						enum: ['issue@1.0.0', 'pull-request@1.0.0', 'check-run@1.0.0'],
+					},
+					name: {
+						type: ['null', 'string'],
+					},
+					data: {
+						type: 'object',
+					},
+				},
+			},
+			action: 'action-integration-github-mirror-event@1.0.0',
+			target: {
+				$eval: 'source.id',
+			},
+			arguments: {},
+		},
+	};

--- a/lib/contracts/triggered-action-integration-github-mirror-event.ts
+++ b/lib/contracts/triggered-action-integration-github-mirror-event.ts
@@ -6,25 +6,30 @@ export const triggeredActionIntegrationGitHubMirrorEvent: ContractDefinition = {
 	name: 'Triggered action for GitHub mirrors',
 	markers: [],
 	data: {
-		schedule: 'sync',
 		filter: {
 			type: 'object',
 			required: ['type'],
 			properties: {
 				type: {
 					type: 'string',
-					enum: [
-						'message@1.0.0',
-						'issue@1.0.0',
-						'pull-request@1.0.0',
-						'check-run@1.0.0',
-					],
+					const: 'message@1.0.0',
 				},
 				name: {
 					type: ['null', 'string'],
 				},
 				data: {
 					type: 'object',
+				},
+			},
+			$$links: {
+				'is attached to': {
+					type: 'object',
+					properties: {
+						type: {
+							type: 'string',
+							enum: ['issue@1.0.0', 'pull-request@1.0.0'],
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Brings in the changes originally proposed in https://github.com/product-os/jellyfish-plugin-github/pull/923
but omits the `integration_source` change and keeps the existing triggered action slug the same so that no manual migration is needed

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>