### PR TITLE
Update triggers that use link 'has attached check run' to 'has attached'

### DIFF
--- a/lib/contracts/triggered-action-conclude-check-run.ts
+++ b/lib/contracts/triggered-action-conclude-check-run.ts
@@ -9,7 +9,7 @@ export const triggeredActionConcludeCheckRun: ContractDefinition = {
 		schedule: 'sync',
 		filter: {
 			$$links: {
-				'has attached check run': {
+				'has attached': {
 					type: 'object',
 					required: ['active', 'type'],
 					properties: {
@@ -66,7 +66,7 @@ export const triggeredActionConcludeCheckRun: ContractDefinition = {
 		action: 'action-update-card@1.0.0',
 		target: {
 			$map: {
-				$eval: "source.links['has attached check run']",
+				$eval: "source.links['has attached']",
 			},
 			'each(link)': {
 				$eval: 'link.id',

--- a/lib/contracts/triggered-action-failed-check-run.ts
+++ b/lib/contracts/triggered-action-failed-check-run.ts
@@ -9,7 +9,7 @@ export const triggeredActionFailedCheckRun: ContractDefinition = {
 		schedule: 'sync',
 		filter: {
 			$$links: {
-				'has attached check run': {
+				'has attached': {
 					type: 'object',
 					required: ['active', 'type'],
 					properties: {
@@ -66,7 +66,7 @@ export const triggeredActionFailedCheckRun: ContractDefinition = {
 		action: 'action-update-card@1.0.0',
 		target: {
 			$map: {
-				$eval: "source.links['has attached check run']",
+				$eval: "source.links['has attached']",
 			},
 			'each(link)': {
 				$eval: 'link.id',

--- a/lib/contracts/triggered-action-in-progress-check-run.ts
+++ b/lib/contracts/triggered-action-in-progress-check-run.ts
@@ -9,7 +9,7 @@ export const triggeredActionInProgressCheckRun: ContractDefinition = {
 		schedule: 'sync',
 		filter: {
 			$$links: {
-				'has attached check run': {
+				'has attached': {
 					type: 'object',
 					required: ['active', 'type'],
 					properties: {
@@ -66,7 +66,7 @@ export const triggeredActionInProgressCheckRun: ContractDefinition = {
 		action: 'action-update-card@1.0.0',
 		target: {
 			$map: {
-				$eval: "source.links['has attached check run']",
+				$eval: "source.links['has attached']",
 			},
 			'each(link)': {
 				$eval: 'link.id',


### PR DESCRIPTION
Fix due to recent relationship change

Change-type: patch