### PR TITLE
Add action and trigger for syncing GitHub orgs

### DIFF
--- a/lib/actions/action-integration-github-sync-org-from-repo.ts
+++ b/lib/actions/action-integration-github-sync-org-from-repo.ts
@@ -1,0 +1,221 @@
+import { defaultEnvironment } from '@balena/jellyfish-environment';
+import type { TypeContract } from '@balena/jellyfish-types/build/core';
+import type { ActionDefinition } from '@balena/jellyfish-worker';
+import { getLogger, LogContext } from '@balena/jellyfish-logger';
+import * as _ from 'lodash';
+import { GithubIntegration } from '../integrations/github';
+
+const logger = getLogger(__filename);
+
+// Stub the context.log object required for the GitHub integration class
+const getContextLogger = (logContext: LogContext) => {
+	return {
+		warn: (message: string, data: any) => {
+			logger.warn(logContext, message, data);
+		},
+		error: (message: string, data: any) => {
+			logger.error(logContext, message, data);
+		},
+		debug: (message: string, data: any) => {
+			logger.debug(logContext, message, data);
+		},
+		info: (message: string, data: any) => {
+			logger.info(logContext, message, data);
+		},
+		exception: (message: string, error: any) => {
+			logger.exception(logContext, message, error);
+		},
+	};
+};
+
+// Instantiate an integration instance, so that we can re-use the logic for
+// setting up an authenticated Octokit instance.
+// The full sync-context object isn't used here as all we need is the log interface.
+const integration = new GithubIntegration({
+	token: defaultEnvironment.integration.github,
+	log: getContextLogger({ id: 'github-integration' }),
+});
+
+const handler: ActionDefinition['handler'] = async (
+	session,
+	context,
+	card,
+	request,
+) => {
+	const ghOrgSlug = card.data.owner as string;
+	// Check to see if the org exists
+	let [org] = await context.query(
+		session,
+		{
+			type: 'object',
+			properties: {
+				type: {
+					const: 'github-org',
+				},
+				data: {
+					type: 'object',
+					properties: {
+						mirrors: {
+							type: 'array',
+							contains: {
+								type: 'string',
+								const: `https://github.com/${ghOrgSlug}`,
+							},
+						},
+					},
+				},
+			},
+		},
+		{ limit: 1 },
+	);
+
+	// If the org already exists, check to see if we need to create a link to it
+	if (org) {
+		const [repoWithLink] = await context.query(
+			session,
+			{
+				$$links: {
+					'belongs to': {
+						type: 'object',
+						properties: {
+							type: {
+								const: 'github-org',
+							},
+						},
+					},
+				},
+				type: 'object',
+				properties: {
+					type: {
+						const: 'repository@1.0.0',
+					},
+					id: {
+						const: card.id,
+					},
+				},
+			},
+			{ limit: 1 },
+		);
+
+		// If the org and link exist, we're done
+		if (repoWithLink) {
+			return {
+				id: org.id,
+				type: org.type,
+				version: org.version,
+				slug: org.slug,
+			};
+		}
+	} else {
+		// Otherwise fetch the org from GitHub and create a new contract for it
+		const integrationContext = {
+			log: getContextLogger(request.logContext),
+		};
+		const installationId = await integration.getInstallationId(
+			integrationContext,
+			ghOrgSlug,
+		);
+		const octokit = await integration.getOctokit(
+			integrationContext,
+			installationId,
+		);
+		if (!octokit) {
+			throw new Error('Could not get authenticate with GitHub');
+		}
+		const result = await octokit.orgs.get({
+			org: ghOrgSlug,
+		});
+
+		if (!result) {
+			throw new Error(`Could not get retrieve org from GitHub: ${ghOrgSlug}`);
+		}
+
+		const orgTypeContract = context.cards['github-org@1.0.0'] as TypeContract;
+		const orgResult = await context.insertCard(
+			session,
+			orgTypeContract,
+			{
+				timestamp: request.timestamp,
+				actor: request.actor,
+				originator: request.originator,
+				reason: request.arguments.reason,
+				attachEvents: true,
+			},
+			{
+				type: 'github-org@1.0.0',
+				name: result.data.name,
+				data: {
+					github_id: result.data.id,
+					description: result.data.description,
+					login: result.data.login,
+					avatar_url: result.data.avatar_url,
+					url: result.data.url,
+				},
+			},
+		);
+
+		if (!orgResult) {
+			throw new Error(`Could not create org in database: ${ghOrgSlug}`);
+		}
+
+		org = orgResult;
+	}
+
+	// Finally link the org to the repoitory contract
+	const linkTypeContract = context.cards['link@1.0.0'] as TypeContract;
+	await context.insertCard(
+		session,
+		linkTypeContract,
+		{
+			timestamp: request.timestamp,
+			actor: request.actor,
+			originator: request.originator,
+			reason: request.arguments.reason,
+			attachEvents: true,
+		},
+		{
+			type: 'link@1.0.0',
+			name: 'belongs to',
+			data: {
+				inverseName: 'has',
+				from: {
+					id: card.id,
+					type: card.type,
+				},
+				to: {
+					id: org.id,
+					type: org.type,
+				},
+			},
+		},
+	);
+
+	return {
+		id: org.id,
+		type: org.type,
+		version: org.version,
+		slug: org.slug,
+	};
+};
+
+export const actionIntegrationGitHubMirrorEvent: ActionDefinition = {
+	handler,
+	contract: {
+		slug: 'action-integration-github-mirror-event',
+		version: '1.0.0',
+		type: 'action@1.0.0',
+		data: {
+			filter: {
+				type: 'object',
+				required: ['type'],
+				properties: {
+					type: {
+						type: 'string',
+						const: 'repository@1.0.0',
+					},
+				},
+			},
+			arguments: {},
+		},
+	},
+};

--- a/lib/contracts/github-org.ts
+++ b/lib/contracts/github-org.ts
@@ -15,9 +15,21 @@ export const githubOrg: ContractDefinition = {
 				data: {
 					type: 'object',
 					properties: {
+						github_id: {
+							type: 'string',
+						},
 						description: {
 							type: 'string',
 							format: 'markdown',
+						},
+						login: {
+							type: 'string',
+						},
+						avatar_url: {
+							type: 'string',
+						},
+						url: {
+							type: 'string',
 						},
 					},
 				},

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -23,6 +23,7 @@ import { relationshipPullRequestHasAttachedPattern } from './relationship-pull-r
 import { relationshipPullRequestHasBaseAtRepository } from './relationship-pull-request-has-base-at-repository';
 import { relationshipPullRequestHasHeadAtRepository } from './relationship-pull-request-has-head-at-repository';
 import { relationshipPushRefersToRepository } from './relationship-push-refers-to-repository';
+import { relationshipRepositoryBelongsToGitHubOrg } from './relationship-repository-belongs-to-github-org';
 import { relationshipRepositoryHasThread } from './relationship-repository-has-thread';
 import { relationshipRepositoryUsesRepository } from './relationship-repository-uses-repository';
 import { relationshipSalesThreadIsAttachedToIssue } from './relationship-sales-thread-is-attached-to-issue';
@@ -35,6 +36,7 @@ import { triggeredActionGitHubIssueLink } from './triggered-action-github-issue-
 import { triggeredActionInProgressCheckRun } from './triggered-action-in-progress-check-run';
 import { triggeredActionIntegrationGitHubMirrorEntities } from './triggered-action-integration-github-mirror-entities';
 import { triggeredActionIntegrationGitHubMirrorEvent } from './triggered-action-integration-github-mirror-event';
+import { triggeredActionIntegrationGitHubSyncOrgFromRepo } from './triggered-action-integration-github-sync-org-from-repo';
 import { triggeredActionSupportClosedIssueReopen } from './triggered-action-support-closed-issue-reopen';
 import { triggeredActionSupportClosedPullRequestReopen } from './triggered-action-support-closed-pull-request-reopen';
 import { viewAllIssues } from './view-all-issues';
@@ -65,6 +67,7 @@ export const contracts: ContractDefinition[] = [
 	relationshipPullRequestHasBaseAtRepository,
 	relationshipPullRequestHasHeadAtRepository,
 	relationshipPushRefersToRepository,
+	relationshipRepositoryBelongsToGitHubOrg,
 	relationshipRepositoryHasThread,
 	relationshipRepositoryUsesRepository,
 	relationshipSalesThreadIsAttachedToIssue,
@@ -77,6 +80,7 @@ export const contracts: ContractDefinition[] = [
 	triggeredActionInProgressCheckRun,
 	triggeredActionIntegrationGitHubMirrorEntities,
 	triggeredActionIntegrationGitHubMirrorEvent,
+	triggeredActionIntegrationGitHubSyncOrgFromRepo,
 	triggeredActionSupportClosedIssueReopen,
 	triggeredActionSupportClosedPullRequestReopen,
 	viewAllIssues,

--- a/lib/contracts/relationship-repository-belongs-to-github-org.ts
+++ b/lib/contracts/relationship-repository-belongs-to-github-org.ts
@@ -1,0 +1,19 @@
+import type { RelationshipContractDefinition } from 'autumndb';
+
+export const relationshipRepositoryBelongsToGitHubOrg: RelationshipContractDefinition =
+	{
+		slug: 'relationship-repository-belongs-to-github-org',
+		type: 'relationship@1.0.0',
+		name: 'belongs to',
+		data: {
+			inverseName: 'has',
+			title: 'Belongs to GitHub org',
+			inverseTitle: 'Has Repository',
+			from: {
+				type: 'repository',
+			},
+			to: {
+				type: 'github-org',
+			},
+		},
+	};

--- a/lib/contracts/triggered-action-integration-github-sync-org-from-repo.ts
+++ b/lib/contracts/triggered-action-integration-github-sync-org-from-repo.ts
@@ -1,0 +1,28 @@
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+
+export const triggeredActionIntegrationGitHubSyncOrgFromRepo: ContractDefinition =
+	{
+		slug: 'triggered-action-integration-github-sync-org-from-repo',
+		type: 'triggered-action@1.0.0',
+		name: 'Triggered action for syncing GitHub orgs',
+		markers: [],
+		data: {
+			filter: {
+				type: 'object',
+				properties: {
+					type: {
+						type: 'string',
+						const: 'repository@1.0.0',
+					},
+					data: {
+						type: 'object',
+					},
+				},
+			},
+			action: 'action-integration-github-sync-org-from-repo@1.0.0',
+			target: {
+				$eval: 'source.id',
+			},
+			arguments: {},
+		},
+	};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@balena/jellyfish-plugin-github",
   "description": "GitHub Jellyfish Plugin",
-  "version": "6.0.25",
+  "version": "6.0.19",
   "repository": {
     "type": "git",
     "url": "https://github.com/product-os/jellyfish-plugin-github"
@@ -46,22 +46,22 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@balena/jellyfish-assert": "^1.2.39",
-    "@balena/jellyfish-worker": "^30.1.0",
+    "@balena/jellyfish-assert": "^1.2.38",
+    "@balena/jellyfish-environment": "^12.0.11",
+    "@balena/jellyfish-worker": "^30.0.21",
     "@octokit/auth-app": "^3.6.1",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^3.6.2",
     "@octokit/rest": "^18.12.0",
-    "autumndb": "^20.2.1",
+    "autumndb": "^20.1.21",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2",
     "yaml": "^1.10.2"
   },
   "devDependencies": {
-    "@balena/jellyfish-config": "^2.0.7",
-    "@balena/jellyfish-environment": "^12.1.0",
-    "@balena/jellyfish-plugin-default": "^27.8.19",
-    "@balena/jellyfish-plugin-product-os": "^7.0.29",
+    "@balena/jellyfish-config": "^2.0.6",
+    "@balena/jellyfish-plugin-default": "^27.8.13",
+    "@balena/jellyfish-plugin-product-os": "^7.0.27",
     "@balena/jellyfish-types": "^2.0.5",
     "@balena/lint": "^6.2.0",
     "@types/jest": "^28.1.2",
@@ -75,13 +75,13 @@
     "rimraf": "^3.0.2",
     "simple-git-hooks": "^2.8.0",
     "ts-jest": "^28.0.5",
-    "typedoc": "^0.23.5",
+    "typedoc": "^0.22.17",
     "typescript": "4.7.4"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
   },
   "versionist": {
-    "publishedAt": "2022-07-02T20:09:19.776Z"
+    "publishedAt": "2022-06-21T03:50:08.258Z"
   }
 }


### PR DESCRIPTION
This approach aims to reduce complexity by using a triggered action
specifically for syncing github orgs when a repo is updated/inserted.

I've re-used the Octokit setup from the integration class, as it has
some complicated logic for determining which app installation to use
when making requests. In the future I would hope to install apps into
loops and skip this step, but for now it made sense to re-use the code
instead of duplicating it.

Resolves https://github.com/product-os/jellyfish/issues/8784

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>