### PR TITLE
Drop jellyfish-environment

### DIFF
--- a/lib/environment.ts
+++ b/lib/environment.ts
@@ -1,0 +1,48 @@
+import _ from 'lodash';
+
+interface Environment {
+	api: string;
+	signature: string;
+	key: string;
+	appId: number;
+	test: {
+		repo: string;
+	};
+}
+
+function getPrivateKey(): string | undefined {
+	const raw = process.env['INTEGRATION_GITHUB_PRIVATE_KEY'];
+	if (raw) {
+		return Buffer.from(raw.replace(/\\n/gm, '\n'), 'base64').toString();
+	}
+	return undefined;
+}
+
+function getAppId(): number | undefined {
+	const raw = process.env['INTEGRATION_GITHUB_APP_ID'];
+	if (raw) {
+		return _.parseInt(raw);
+	}
+	return undefined;
+}
+
+export const defaults: Environment = {
+	api: '',
+	signature: 'MnDdSk4JT3e6tkiAUdHfD7Mrs6SUrv',
+	key: '',
+	appId: 0,
+	test: {
+		repo: 'product-os-test/jellyfish-test-github',
+	},
+};
+
+export const environment: Environment = {
+	api: process.env['INTEGRATION_GITHUB_TOKEN'] || defaults.api,
+	signature:
+		process.env['INTEGRATION_GITHUB_SIGNATURE_KEY'] || defaults.signature,
+	key: getPrivateKey() || defaults.key,
+	appId: getAppId() || defaults.appId,
+	test: {
+		repo: process.env['TEST_INTEGRATION_GITHUB_REPO'] || defaults.test.repo,
+	},
+};

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.38",
-    "@balena/jellyfish-environment": "^12.2.0",
     "@balena/jellyfish-worker": "^31.0.2",
     "@octokit/auth-app": "^3.6.1",
     "@octokit/plugin-retry": "^3.0.9",

--- a/test/integration/github-mirror.spec.ts
+++ b/test/integration/github-mirror.spec.ts
@@ -1,6 +1,5 @@
 import { strict as assert } from 'assert';
 import { testUtils as coreTestUtils } from 'autumndb';
-import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { defaultPlugin } from '@balena/jellyfish-plugin-default';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { retry } from '@octokit/plugin-retry';
@@ -8,6 +7,7 @@ import { Octokit as OctokitRest } from '@octokit/rest';
 import _ from 'lodash';
 import { v4 as uuid } from 'uuid';
 import { githubPlugin, testUtils } from '../../lib';
+import { environment } from '../../lib/environment';
 
 let ctx: testUtils.TestContext;
 let user: any = {};
@@ -15,8 +15,7 @@ let session: any = {};
 let github: any = {};
 let username: string = '';
 
-const [owner, repo] =
-	defaultEnvironment.test.integration.github.repo.split('/');
+const [owner, repo] = environment.test.repo.split('/');
 const repository = {
 	owner: owner.trim(),
 	repo: repo.trim(),
@@ -37,7 +36,7 @@ beforeAll(async () => {
 			retries: 5,
 		},
 		userAgent: `github-mirror-test-agent (${__dirname})`,
-		auth: defaultEnvironment.integration.github.api,
+		auth: environment.api,
 	});
 });
 

--- a/test/unit/environment/defaults.spec.ts
+++ b/test/unit/environment/defaults.spec.ts
@@ -1,0 +1,5 @@
+import { defaults, environment } from '../../../lib/environment';
+
+test('Default environment variable values are set', () => {
+	expect(environment).toEqual(defaults);
+});

--- a/test/unit/environment/overrides.spec.ts
+++ b/test/unit/environment/overrides.spec.ts
@@ -1,0 +1,26 @@
+process.env.INTEGRATION_GITHUB_TOKEN = 'foo';
+process.env.INTEGRATION_GITHUB_SIGNATURE_KEY = 'bar';
+process.env.INTEGRATION_GITHUB_PRIVATE_KEY = 'YnV6';
+process.env.INTEGRATION_GITHUB_APP_ID = '1337';
+process.env.TEST_INTEGRATION_GITHUB_REPO = 'foo/bar';
+
+import { environment } from '../../../lib/environment';
+
+afterAll(() => {
+	delete process.env.INTEGRATION_GITHUB_TOKEN;
+	delete process.env.INTEGRATION_GITHUB_SIGNATURE_KEY;
+	delete process.env.INTEGRATION_GITHUB_PRIVATE_KEY;
+	delete process.env.INTEGRATION_GITHUB_APP_ID;
+});
+
+test('Can override environment variable defaults', () => {
+	expect(environment).toEqual({
+		api: 'foo',
+		signature: 'bar',
+		key: 'buz',
+		appId: 1337,
+		test: {
+			repo: 'foo/bar',
+		},
+	});
+});

--- a/test/unit/integrations/github.spec.ts
+++ b/test/unit/integrations/github.spec.ts
@@ -9,10 +9,7 @@ describe('isEventValid()', () => {
 	test('should return false given no signature header', async () => {
 		const result = githubIntegrationDefinition.isEventValid(
 			logContext,
-			{
-				api: 'xxxxx',
-				signature: 'secret',
-			},
+			null,
 			'....',
 			{},
 		);
@@ -32,10 +29,7 @@ describe('isEventValid()', () => {
 	test('should return false given a signature mismatch', async () => {
 		const result = githubIntegrationDefinition.isEventValid(
 			logContext,
-			{
-				api: 'xxxxx',
-				signature: 'secret',
-			},
+			null,
 			'{"foo":"bar"}',
 			{ 'x-hub-signature': 'sha1=foobarbaz' },
 		);
@@ -45,12 +39,9 @@ describe('isEventValid()', () => {
 	test('should return true given a signature match', async () => {
 		const result = githubIntegrationDefinition.isEventValid(
 			logContext,
-			{
-				api: 'xxxxx',
-				signature: 'secret',
-			},
+			null,
 			'{"foo":"bar"}',
-			{ 'x-hub-signature': 'sha1=52b582138706ac0c597c315cfc1a1bf177408a4d' },
+			{ 'x-hub-signature': 'sha1=1a20b3c676d16f4a74243d96e9712b1219fc7553' },
 		);
 		expect(result).toBe(true);
 	});


### PR DESCRIPTION
Remove jellyfish-environment dependency and manage
supported environment variables through process.env instead

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>