### PR TITLE
Rename 'commit was built into error' relationship.

### DIFF
--- a/lib/contracts/commit.ts
+++ b/lib/contracts/commit.ts
@@ -47,10 +47,10 @@ export const commit: ContractDefinition = contractMixins.mixin(
 								mergeable: {
 									description: 'all downstream contracts are mergeable',
 									type: 'string',
-									$$formula: `contract.links["was built into"].length <= 0 ? "pending" :
-											![true, false].includes(contract.links["was built into"][0].data.$transformer.mergeable) ?
-											contract.links["was built into"][0].data.$transformer.mergeable :
-											contract.links["was built into"][0].data.$transformer.mergeable === true ? "mergeable" : "pending"`,
+									$$formula: `contract.links["was transformed to"].length <= 0 ? "pending" :
+											![true, false].includes(contract.links["was transformed to"][0].data.$transformer.mergeable) ?
+											contract.links["was transformed to"][0].data.$transformer.mergeable :
+											contract.links["was transformed to"][0].data.$transformer.mergeable === true ? "mergeable" : "pending"`,
 									readOnly: true,
 									default: false,
 								},

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -8,7 +8,7 @@ import { push } from './push';
 import { relationshipBrainstormTopicHasAttachedIssue } from './relationship-brainstorm-topic-has-attached-issue';
 import { relationshipCommitHasAttachedCheckRun } from './relationship-commit-has-attached-check-run';
 import { relationshipCommitIsAttachedToPullRequest } from './relationship-commit-is-attached-to-pull-request';
-import { relationshipCommitWasBuiltIntoError } from './relationship-commit-was-built-into-error';
+import { relationshipCommitWasTransformedToError } from './relationship-commit-was-transformed-to-error';
 import { relationshipGitHubOrgBelongsToLoop } from './relationship-github-org-belongs-to-loop';
 import { relationshipGitHubOrgHasThread } from './relationship-github-org-has-thread';
 import { relationshipImprovementIsAttachedToIssue } from './relationship-improvement-is-attached-to-issue';
@@ -52,7 +52,7 @@ export const contracts: ContractDefinition[] = [
 	relationshipBrainstormTopicHasAttachedIssue,
 	relationshipCommitHasAttachedCheckRun,
 	relationshipCommitIsAttachedToPullRequest,
-	relationshipCommitWasBuiltIntoError,
+	relationshipCommitWasTransformedToError,
 	relationshipGitHubOrgBelongsToLoop,
 	relationshipGitHubOrgHasThread,
 	relationshipImprovementIsAttachedToIssue,

--- a/lib/contracts/relationship-commit-was-transformed-to-error.ts
+++ b/lib/contracts/relationship-commit-was-transformed-to-error.ts
@@ -1,12 +1,12 @@
 import type { RelationshipContractDefinition } from 'autumndb';
 
-export const relationshipCommitWasBuiltIntoError: RelationshipContractDefinition =
+export const relationshipCommitWasTransformedToError: RelationshipContractDefinition =
 	{
-		slug: 'relationship-commit-was-built-into-error',
+		slug: 'relationship-commit-was-transformed-to-error',
 		type: 'relationship@1.0.0',
-		name: 'was built into',
+		name: 'was transformed to',
 		data: {
-			inverseName: 'was built from',
+			inverseName: 'was transformed from',
 			title: 'Error',
 			inverseTitle: 'Commit',
 			from: {

--- a/lib/types/contracts/index.ts
+++ b/lib/types/contracts/index.ts
@@ -15,25 +15,25 @@ export type {
 	CommitData,
 } from './commit';
 export type {
-	GhPushContract,
-	GhPushContractDefinition,
-	GhPushData,
-} from './gh-push';
+	IssueContract,
+	IssueContractDefinition,
+	IssueData,
+} from './issue';
 export type {
 	GithubOrgContract,
 	GithubOrgContractDefinition,
 	GithubOrgData,
 } from './github-org';
 export type {
-	IssueContract,
-	IssueContractDefinition,
-	IssueData,
-} from './issue';
-export type {
 	PullRequestContract,
 	PullRequestContractDefinition,
 	PullRequestData,
 } from './pull-request';
+export type {
+	GhPushContract,
+	GhPushContractDefinition,
+	GhPushData,
+} from './gh-push';
 export type {
 	RepositoryContract,
 	RepositoryContractDefinition,

--- a/test/integration/contracts/triggered-action-failed-check-run.spec.ts
+++ b/test/integration/contracts/triggered-action-failed-check-run.spec.ts
@@ -24,11 +24,11 @@ beforeAll(async () => {
 			attachEvents: false,
 		},
 		{
-			slug: 'relationship-commit-was-built-into-card',
+			slug: 'relationship-commit-was-trasformed-to-card',
 			type: 'relationship@1.0.0',
-			name: 'was built into',
+			name: 'was transformed to',
 			data: {
-				inverseName: 'was built from',
+				inverseName: 'was transformed from',
 				title: 'Commit',
 				inverseTitle: 'Card',
 				from: {
@@ -105,8 +105,8 @@ describe('triggered-action-failed-check-run', () => {
 			session.id,
 			commit,
 			card,
-			'was built into',
-			'was built from',
+			'was transformed to',
+			'was transformed from',
 		);
 
 		await ctx.flushAll(session.id);
@@ -152,8 +152,8 @@ describe('triggered-action-failed-check-run', () => {
 			session.id,
 			commit,
 			card,
-			'was built into',
-			'was built from',
+			'was transformed to',
+			'was transformed from',
 		);
 
 		await ctx.flushAll(session.id);
@@ -199,8 +199,8 @@ describe('triggered-action-failed-check-run', () => {
 			session.id,
 			commit,
 			card,
-			'was built into',
-			'was built from',
+			'was transformed to',
+			'was transformed from',
 		);
 
 		await ctx.flushAll(session.id);
@@ -246,8 +246,8 @@ describe('triggered-action-failed-check-run', () => {
 			session.id,
 			commit,
 			card,
-			'was built into',
-			'was built from',
+			'was transformed to',
+			'was transformed from',
 		);
 
 		await ctx.flushAll(session.id);
@@ -293,8 +293,8 @@ describe('triggered-action-failed-check-run', () => {
 			session.id,
 			commit,
 			card,
-			'was built into',
-			'was built from',
+			'was transformed to',
+			'was transformed from',
 		);
 
 		await ctx.flushAll(session.id);


### PR DESCRIPTION
The relationship is now 'commit was transformed to error'.
This is to better align the terminology with transformers.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>