### PR TITLE
Materialize linked loop contract on repository

### DIFF
--- a/lib/contracts/repository.ts
+++ b/lib/contracts/repository.ts
@@ -29,6 +29,12 @@ export const repository: ContractDefinition = {
 						html_url: {
 							type: 'string',
 						},
+						is_used_by: {
+							description: 'The id of the loop that uses this repository',
+							type: 'string',
+							$$formula:
+								'contract.links["is used by"] && contract.links["is used by"].length && FILTER(contract.links["is used by"], { type: "loop@1.0.0" }).length ? FILTER(contract.links["is used by"], { type: "loop@1.0.0" })[0].id : ""',
+						},
 					},
 				},
 			},

--- a/lib/types/contracts/index.ts
+++ b/lib/types/contracts/index.ts
@@ -15,25 +15,25 @@ export type {
 	CommitData,
 } from './commit';
 export type {
-	IssueContract,
-	IssueContractDefinition,
-	IssueData,
-} from './issue';
+	GhPushContract,
+	GhPushContractDefinition,
+	GhPushData,
+} from './gh-push';
 export type {
 	GithubOrgContract,
 	GithubOrgContractDefinition,
 	GithubOrgData,
 } from './github-org';
 export type {
+	IssueContract,
+	IssueContractDefinition,
+	IssueData,
+} from './issue';
+export type {
 	PullRequestContract,
 	PullRequestContractDefinition,
 	PullRequestData,
 } from './pull-request';
-export type {
-	GhPushContract,
-	GhPushContractDefinition,
-	GhPushData,
-} from './gh-push';
 export type {
 	RepositoryContract,
 	RepositoryContractDefinition,

--- a/lib/types/contracts/repository.ts
+++ b/lib/types/contracts/repository.ts
@@ -13,6 +13,10 @@ export interface RepositoryData {
 	name?: string;
 	git_url?: string;
 	html_url?: string;
+	/**
+	 * The id of the loop that uses this repository
+	 */
+	is_used_by?: string;
 	[k: string]: unknown;
 }
 

--- a/test/integration/contracts/repository.spec.ts
+++ b/test/integration/contracts/repository.spec.ts
@@ -1,0 +1,59 @@
+import { testUtils as coreTestUtils } from 'autumndb';
+import { defaultPlugin } from '@balena/jellyfish-plugin-default';
+import _ from 'lodash';
+import { githubPlugin, RepositoryContract, testUtils } from '../../../lib';
+
+let ctx: testUtils.TestContext;
+let user: any = {};
+let session: any = {};
+
+beforeAll(async () => {
+	ctx = await testUtils.newContext({
+		plugins: [defaultPlugin(), githubPlugin()],
+	});
+
+	// Prepare test user and session
+	user = await ctx.createUser(coreTestUtils.generateRandomId());
+	session = await ctx.createSession(user);
+});
+
+afterAll(() => {
+	return testUtils.destroyContext(ctx);
+});
+
+test('Should materialize the linked loop', async () => {
+	const repository = await ctx.createContract(
+		user.id,
+		session.id,
+		'repository@1.0.0',
+		'test repo',
+		{},
+	);
+
+	const loop = await ctx.kernel.getContractBySlug(
+		ctx.logContext,
+		ctx.session,
+		'loop-product-os@1.0.0',
+	);
+
+	await ctx.createLinkThroughWorker(
+		user.id,
+		session.id,
+		repository,
+		loop!,
+		'is used by',
+		'has',
+	);
+
+	await ctx.flushAll(ctx.session);
+
+	const result = await ctx.kernel.getContractById<RepositoryContract>(
+		ctx.logContext,
+		ctx.session,
+		repository.id,
+	);
+
+	expect(result).not.toBeNull();
+
+	expect(result!.data.is_used_by).toBe(loop!.id);
+});

--- a/test/integration/webhooks/moving-repo-between-orgs/expected.json
+++ b/test/integration/webhooks/moving-repo-between-orgs/expected.json
@@ -16,7 +16,8 @@
       "mirrors": [
         "https://api.github.com/repos/loop-os-staging/to-be-moved"
       ],
-      "integration_source": "github"
+      "integration_source": "github",
+      "is_used_by": ""
     }
   },
   "tail": [

--- a/test/integration/webhooks/moving-repo-between-user/expected.json
+++ b/test/integration/webhooks/moving-repo-between-user/expected.json
@@ -16,7 +16,8 @@
       "mirrors": [
         "https://api.github.com/repos/loop-os-staging/users-repo-to-be-moved"
       ],
-      "integration_source": "github"
+      "integration_source": "github",
+      "is_used_by": ""
     }
   },
   "tail": [

--- a/test/integration/webhooks/open-pr-and-create-repos/expected.json
+++ b/test/integration/webhooks/open-pr-and-create-repos/expected.json
@@ -11,7 +11,8 @@
       "html_url": "https://github.com/resin-io/jellyfish",
       "name":  "jellyfish",
       "owner":  "resin-io",
-      "integration_source": "github"
+      "integration_source": "github",
+      "is_used_by": ""
     },
     "requires": [ ],
     "tags": [ ],

--- a/test/integration/webhooks/repo-create/expected.json
+++ b/test/integration/webhooks/repo-create/expected.json
@@ -15,7 +15,8 @@
       "html_url": "https://github.com/loop-os/repo-create",
       "mirrors": [
         "https://api.github.com/repos/loop-os/repo-create"
-      ]
+      ],
+      "is_used_by": ""
     }
   },
   "tail": [

--- a/test/integration/webhooks/repo-rename/expected.json
+++ b/test/integration/webhooks/repo-rename/expected.json
@@ -15,7 +15,8 @@
       "html_url": "https://github.com/loop-os/renamed",
       "mirrors": [
         "https://api.github.com/repos/loop-os/renamed"
-      ]
+      ],
+      "is_used_by": ""
     }
   },
   "tail": [


### PR DESCRIPTION
This is a workaround for https://github.com/product-os/autumndb/issues/1396 that will allow clients to traverse relationships.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>