### PR TITLE
CI: Temporarily remove flowzone workflow

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1,7 +1,0 @@
-name: Flowzone
-
-on: pull_request
-
-jobs:
-  flowzone:
-    uses: product-os/flowzone/.github/workflows/flowzone.yml@master

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.49",
     "@balena/jellyfish-environment": "^12.3.5",
-    "@balena/jellyfish-worker": "^32.3.1",
+    "@balena/jellyfish-worker": "^33.0.10",
     "@octokit/auth-app": "^3.6.1",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^3.6.2",


### PR DESCRIPTION
Flowzone apparently isn't working for this repo
at the moment and is blocking all PRs. Will bring
back once flowzone is a working option.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>